### PR TITLE
Add support for Source config

### DIFF
--- a/segment/sources.go
+++ b/segment/sources.go
@@ -80,3 +80,57 @@ func (c *Client) DeleteSource(srcName string) error {
 
 	return nil
 }
+
+// GetSourceConfig retrieves the schema config of a given source
+// API Doc: https://reference.segmentapis.com/#c74efb9b-b09e-4072-8da1-ba6ca60e6a78
+func (c *Client) GetSourceConfig(srcName string) (SourceConfig, error) {
+	var result SourceConfig
+
+	response, err := c.doRequest(http.MethodGet, fmt.Sprintf("%s/%s/%s/%s/schema-config", WorkspacesEndpoint, c.workspace, SourceEndpoint, srcName), nil)
+	if err != nil {
+		return result, err
+	}
+
+	err = json.Unmarshal(response, &result)
+	if err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+// UpdateSourceConfig updates the schema config of a given source
+// API Doc: https://reference.segmentapis.com/#af54244f-4ec7-4e78-96e9-8966dd18e56f
+func (c *Client) UpdateSourceConfig(srcName string, config SourceConfig) (SourceConfig, error) {
+	var result SourceConfig
+
+	req := sourceConfigUpdateRequest{
+		Config: config,
+		UpdateMask: UpdateMask{Paths: []string{
+			"schema_config.allow_unplanned_track_events",
+			"schema_config.allow_unplanned_identify_traits",
+			"schema_config.allow_unplanned_group_traits",
+			"schema_config.forwarding_blocked_events_to",
+			"schema_config.allow_unplanned_track_event_properties",
+			"schema_config.allow_track_event_on_violations",
+			"schema_config.allow_identify_traits_on_violations",
+			"schema_config.allow_group_traits_on_violations",
+			"schema_config.forwarding_violations_to",
+			"schema_config.common_track_event_on_violations",
+			"schema_config.common_identify_event_on_violations",
+			"schema_config.common_group_event_on_violations",
+		}},
+	}
+
+	response, err := c.doRequest(http.MethodPatch, fmt.Sprintf("%s/%s/%s/%s/schema-config", WorkspacesEndpoint, c.workspace, SourceEndpoint, srcName), req)
+	if err != nil {
+		return result, err
+	}
+
+	err = json.Unmarshal(response, &result)
+	if err != nil {
+		return result, err
+	}
+
+	return result, nil
+}

--- a/segment/types.go
+++ b/segment/types.go
@@ -1,6 +1,7 @@
 package segment
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -25,6 +26,44 @@ type Source struct {
 	WriteKeys     []string      `json:"write_keys,omitempty"`
 	LibraryConfig LibraryConfig `json:"library_config,omitempty"`
 	CreateTime    time.Time     `json:"create_time,omitempty"`
+}
+
+// CommonEventSettings provides accepted values for CommonTrackEventOnViolations, CommonIdentifyEventOnViolations and CommonGroupEventOnViolations
+type CommonEventSettings string
+
+const (
+	Allow CommonEventSettings = "ALLOW"
+
+	// Only for use with CommonTrackEventOnViolations
+	OmitProps = "OMIT_PROPERTIES"
+
+	// Only for use with CommonIdentifyEventOnViolations and CommonIdentifyEventOnViolations
+	OmitTraits = "OMIT_TRAITS"
+
+	Block = "BLOCK"
+)
+
+type SourceConfig struct {
+	Name                                string              `json:"name,omitempty"`
+	Parent                              string              `json:"parent,omitempty"`
+	AllowUnplannedTrackEvents           bool                `json:"allow_unplanned_track_events,omitempty"`
+	AllowUnplannedIdentifyTraits        bool                `json:"allow_unplanned_identify_traits,omitempty"`
+	AllowUnplannedGroupTraits           bool                `json:"allow_unplanned_group_traits,omitempty"`
+	AllowTrackEventOnViolations         bool                `json:"allow_track_event_on_violations,omitempty"`
+	AllowIdentifyTraitsOnViolations     bool                `json:"allow_identify_traits_on_violations,omitempty"`
+	AllowGroupTraitsOnViolations        bool                `json:"allow_group_traits_on_violations,omitempty"`
+	AllowUnplannedTrackEventsProperties bool                `json:"allow_unplanned_track_event_properties,omitempty"`
+	AllowTrackPropertiesOnViolations    bool                `json:"allow_track_properties_on_violations,omitempty"`
+	ForwardingBlockedEventsTo           string              `json:"forwarding_blocked_events_to,omitempty"`
+	ForwardingViolationsTo              string              `json:"forwarding_violations_to,omitempty"`
+	CommonTrackEventOnViolations        CommonEventSettings `json:"common_track_event_on_violations,omitempty"`
+	CommonIdentifyEventOnViolations     CommonEventSettings `json:"common_identify_event_on_violations,omitempty"`
+	CommonGroupEventOnViolations        CommonEventSettings `json:"common_group_event_on_violations,omitempty"`
+}
+
+type sourceConfigUpdateRequest struct {
+	Config     SourceConfig `json:"schema_config,omitempty"`
+	UpdateMask UpdateMask   `json:"update_mask,omitempty"`
 }
 
 // LibraryConfig contains information about a source's library
@@ -60,7 +99,7 @@ type DestinationConfig struct {
 	Type        string      `json:"type,omitempty"`
 }
 
-// UpdateMask contains information for updating Destinations
+// UpdateMask contains information for updating Destinations and Sources
 type UpdateMask struct {
 	Paths []string `json:"paths,omitempty"`
 }
@@ -145,4 +184,13 @@ type trackingPlanCreateRequest struct {
 type trackingPlanUpdateRequest struct {
 	UpdateMask   UpdateMask   `json:"update_mask,omitempty"`
 	TrackingPlan TrackingPlan `json:"tracking_plan,omitempty"`
+}
+
+type SegmentApiError struct {
+	Message string `json:"error,omitempty"`
+	Code    int    `json:"code,omitempty"`
+}
+
+func (err *SegmentApiError) Error() string {
+	return fmt.Sprintf("Segment Error %d: %s", err.Code, err.Message)
 }

--- a/segment/types.go
+++ b/segment/types.go
@@ -35,12 +35,12 @@ const (
 	Allow CommonEventSettings = "ALLOW"
 
 	// Only for use with CommonTrackEventOnViolations
-	OmitProps = "OMIT_PROPERTIES"
+	OmitProps CommonEventSettings = "OMIT_PROPERTIES"
 
 	// Only for use with CommonIdentifyEventOnViolations and CommonIdentifyEventOnViolations
-	OmitTraits = "OMIT_TRAITS"
+	OmitTraits CommonEventSettings = "OMIT_TRAITS"
 
-	Block = "BLOCK"
+	Block CommonEventSettings = "BLOCK"
 )
 
 type SourceConfig struct {


### PR DESCRIPTION
Support for the 2 following methods:

https://reference.segmentapis.com/#c74efb9b-b09e-4072-8da1-ba6ca60e6a78
https://reference.segmentapis.com/#af54244f-4ec7-4e78-96e9-8966dd18e56f

+ Added error handling in the case of Bad Requests so we propagate segment error's back to the user